### PR TITLE
Feature/load conf from table metdata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.15</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/src/main/scala/org/dbtofile/conf/DataSourceConfiguration.scala
+++ b/src/main/scala/org/dbtofile/conf/DataSourceConfiguration.scala
@@ -76,7 +76,7 @@ case class MergeTableInfo(
   }
 }
 
-
+//todo extract
 object Configuration {
   def loadConfigurationFromYaml( file : File): TableList = {
     val input = new FileInputStream(file)

--- a/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
+++ b/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
@@ -76,9 +76,4 @@ object DataSourceDefinition {
 
 
   }
-
-  def main(args: Array[String]): Unit = {
-    val db = load("jdbc:mysql://192.168.99.100:32783/employees", "root", "root")
-    println(YamlOps.toString(db))
-  }
 }

--- a/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
+++ b/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
@@ -1,0 +1,79 @@
+/*
+ *     Licensed to the Apache Software Foundation (ASF) under one or more
+ *     contributor license agreements.  See the NOTICE file distributed with
+ *     this work for additional information regarding copyright ownership.
+ *     The ASF licenses this file to You under the Apache License, Version 2.0
+ *     (the "License"); you may not use this file except in compliance with
+ *     the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.dbtofile.conf
+
+import java.sql.{DatabaseMetaData, DriverManager}
+
+import org.dbtofile.utils.{DbOps, YamlOps}
+
+import scala.beans.BeanProperty
+
+
+case class Db(@BeanProperty dbName: String,
+              @BeanProperty tables: Array[DbTable],
+              @BeanProperty relations: Array[Relation]) {
+
+  def childTables(table: DbTable): Array[DbTable] = childTables(table.name)
+
+  def childTables(tableName: String): Array[DbTable] = relations
+    .filter(_.baseTable == tableName)
+    .flatMap(r => tables.find(_.name == r.childTable))
+
+}
+
+/**
+  *
+  * @param name
+  * @param dataType java.sql.Types
+  */
+case class Column(@BeanProperty name: String,
+                  @BeanProperty dataType: Int)
+
+case class DbTable(@BeanProperty name: String,
+                   @BeanProperty pk: Array[Column],
+                   @BeanProperty columns: Array[Column])
+
+case class Relation(@BeanProperty baseTable: String,
+                    @BeanProperty basePK: String,
+                    @BeanProperty childTable: String,
+                    @BeanProperty childFK: String)
+
+object DataSourceDefinition {
+  def load(): Db = {
+    val connection = DriverManager.getConnection("jdbc:mysql://192.168.99.100:32783/employees", "root", "root")
+    val metadata: DatabaseMetaData = connection.getMetaData
+
+    val tableNames: List[String] = DbOps.listTables(metadata)
+    val tables: List[(DbTable, List[Relation])] = tableNames.map(tableName => {
+      val columns: Array[Column] = DbOps.listColumns(metadata, tableName).toArray
+      val pk = DbOps.primaryKey(metadata, tableName).toArray
+      val tableRelations = DbOps.relations(metadata, tableName)
+      (DbTable(tableName, pk, columns), tableRelations)
+    })
+
+    Db("employees", tables.map(_._1).toArray, tables.flatMap(_._2).toArray)
+
+
+  }
+
+  def main(args: Array[String]): Unit = {
+    val db = load()
+    println(YamlOps.toString(db))
+  }
+}

--- a/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
+++ b/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
@@ -29,6 +29,11 @@ case class Db(@BeanProperty dbName: String,
               @BeanProperty tables: Array[DbTable],
               @BeanProperty relations: Array[Relation]) {
 
+  /**
+    * List tables that can be joined to specified table
+    * @param table
+    * @return
+    */
   def childTables(table: DbTable): Array[DbTable] = childTables(table.name)
 
   def childTables(tableName: String): Array[DbTable] = relations

--- a/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
+++ b/src/main/scala/org/dbtofile/conf/DataSourceDefinition.scala
@@ -60,8 +60,8 @@ case class Relation(@BeanProperty baseTable: String,
                     @BeanProperty childFK: String)
 
 object DataSourceDefinition {
-  def load(): Db = {
-    val connection = DriverManager.getConnection("jdbc:mysql://192.168.99.100:32783/employees", "root", "root")
+  def load(connectionString:String, user:String, password:String): Db = {
+    val connection = DriverManager.getConnection(connectionString, user, password)
     val metadata: DatabaseMetaData = connection.getMetaData
 
     val tableNames: List[String] = DbOps.listTables(metadata)
@@ -78,7 +78,7 @@ object DataSourceDefinition {
   }
 
   def main(args: Array[String]): Unit = {
-    val db = load()
+    val db = load("jdbc:mysql://192.168.99.100:32783/employees", "root", "root")
     println(YamlOps.toString(db))
   }
 }

--- a/src/main/scala/org/dbtofile/utils/DbOps.scala
+++ b/src/main/scala/org/dbtofile/utils/DbOps.scala
@@ -1,0 +1,73 @@
+/*
+ *     Licensed to the Apache Software Foundation (ASF) under one or more
+ *     contributor license agreements.  See the NOTICE file distributed with
+ *     this work for additional information regarding copyright ownership.
+ *     The ASF licenses this file to You under the Apache License, Version 2.0
+ *     (the "License"); you may not use this file except in compliance with
+ *     the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.dbtofile.utils
+
+import java.sql.DatabaseMetaData
+
+import org.dbtofile.conf.{Column, DbTable, Relation}
+
+object DbOps {
+
+  type TableWithReferences = (DbTable, List[Relation])
+
+  def listTables(metadata: DatabaseMetaData) = {
+
+    val catalog: String = metadata.getConnection.getCatalog
+    val schemaPattern: String = null
+    val tableNamePattern: String = null
+    val types: Array[String] = null
+
+    val tablesRs = metadata.getTables(catalog, schemaPattern, tableNamePattern, types)
+    (for ((_, r) <- Iterator.continually((tablesRs.next(), tablesRs)).takeWhile(_._1)) yield {
+      r.getString(3)
+    }).toList
+  }
+
+  def listColumns(metadata: DatabaseMetaData, table: String) = {
+    val columnsRs = metadata.getColumns(metadata.getConnection.getCatalog, null, table, null)
+    (for ((_, r) <- Iterator.continually((columnsRs.next(), columnsRs)).takeWhile(_._1)) yield {
+      val columnName = r.getString(4)
+      val columnType = r.getInt(5)
+      Column(columnName, columnType)
+    }).toList
+  }
+
+  def primaryKey(metadata: DatabaseMetaData, tableName: String) = {
+    val pkRs = metadata.getPrimaryKeys(null, null, tableName)
+
+    (for ((_, r) <- Iterator.continually((pkRs.next(), pkRs)).takeWhile(_._1)) yield {
+      val columnName = r.getString(4)
+      val columnType = r.getInt(5)
+      Column(columnName, columnType)
+    }).toList
+
+  }
+
+  def relations(metadata: DatabaseMetaData, tableName: String) = {
+    val fkRs = metadata.getImportedKeys(null, null, tableName)
+    (for ((_, r) <- Iterator.continually((fkRs.next(), fkRs)).takeWhile(_._1)) yield {
+      val fkTableName = r.getString("FKTABLE_NAME")
+      val fkColumnName = r.getString("FKCOLUMN_NAME")
+      val pkTableName = r.getString("PKTABLE_NAME")
+      val pkColumnName = r.getString("PKCOLUMN_NAME")
+      Relation(pkTableName, pkColumnName, fkTableName, fkColumnName)
+    }).toList
+
+  }
+}

--- a/src/main/scala/org/dbtofile/utils/DbOps.scala
+++ b/src/main/scala/org/dbtofile/utils/DbOps.scala
@@ -29,9 +29,9 @@ object DbOps {
   def listTables(metadata: DatabaseMetaData) = {
 
     val catalog: String = metadata.getConnection.getCatalog
-    val schemaPattern: String = null
-    val tableNamePattern: String = null
-    val types: Array[String] = null
+    val schemaPattern: String = "public"
+    val tableNamePattern: String = "%"
+    val types: Array[String] = Array("TABLE")
 
     val tablesRs = metadata.getTables(catalog, schemaPattern, tableNamePattern, types)
     (for ((_, r) <- Iterator.continually((tablesRs.next(), tablesRs)).takeWhile(_._1)) yield {

--- a/src/main/scala/org/dbtofile/utils/YamlOps.scala
+++ b/src/main/scala/org/dbtofile/utils/YamlOps.scala
@@ -1,0 +1,34 @@
+/*
+ *     Licensed to the Apache Software Foundation (ASF) under one or more
+ *     contributor license agreements.  See the NOTICE file distributed with
+ *     this work for additional information regarding copyright ownership.
+ *     The ASF licenses this file to You under the Apache License, Version 2.0
+ *     (the "License"); you may not use this file except in compliance with
+ *     the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.dbtofile.utils
+
+
+import org.yaml.snakeyaml.DumperOptions.FlowStyle
+import org.yaml.snakeyaml.{DumperOptions, Yaml}
+import org.yaml.snakeyaml.introspector.BeanAccess
+import org.yaml.snakeyaml.nodes.Tag
+
+object YamlOps {
+  def toString(entity: Any) = {
+    val options = new DumperOptions
+    val yaml = new Yaml(options)
+    yaml.setBeanAccess(BeanAccess.FIELD)
+    yaml.dumpAs(entity, new Tag(entity.getClass.getName), FlowStyle.BLOCK)
+  }
+}

--- a/src/main/scala/org/dbtofile/utils/YamlOps.scala
+++ b/src/main/scala/org/dbtofile/utils/YamlOps.scala
@@ -26,13 +26,13 @@ import org.yaml.snakeyaml.nodes.Tag
 import org.yaml.snakeyaml.representer.Representer
 
 object YamlOps {
-  def toString(entity: Any) = {
+  def toString [T] (entity: T) = {
     val options = new DumperOptions
     options.setDefaultFlowStyle(FlowStyle.BLOCK)
     options.setExplicitStart(false)
 
     val representer = new Representer()
-    representer.addClassTag(entity.getClass, Tag.MAP);
+    representer.addClassTag(entity.getClass, Tag.MAP)
 
     val yaml = new Yaml(representer, options)
 

--- a/src/main/scala/org/dbtofile/utils/YamlOps.scala
+++ b/src/main/scala/org/dbtofile/utils/YamlOps.scala
@@ -23,12 +23,20 @@ import org.yaml.snakeyaml.DumperOptions.FlowStyle
 import org.yaml.snakeyaml.{DumperOptions, Yaml}
 import org.yaml.snakeyaml.introspector.BeanAccess
 import org.yaml.snakeyaml.nodes.Tag
+import org.yaml.snakeyaml.representer.Representer
 
 object YamlOps {
   def toString(entity: Any) = {
     val options = new DumperOptions
-    val yaml = new Yaml(options)
+    options.setDefaultFlowStyle(FlowStyle.BLOCK)
+    options.setExplicitStart(false)
+
+    val representer = new Representer()
+    representer.addClassTag(entity.getClass, Tag.MAP);
+
+    val yaml = new Yaml(representer, options)
+
     yaml.setBeanAccess(BeanAccess.FIELD)
-    yaml.dumpAs(entity, new Tag(entity.getClass.getName), FlowStyle.BLOCK)
+    yaml.dump(entity)
   }
 }

--- a/src/test/resources/tables_conf.yaml
+++ b/src/test/resources/tables_conf.yaml
@@ -3,7 +3,7 @@ tables:
       url: jdbc:mysql://<mysql.host>:3306/employees
       table: employees
       user: foouser
-      password: ***
+      password: SomeP@ssw0rd
       outputPath: target/employee.parquet
       outputFormat: parquet
       load: false

--- a/src/test/scala/org/dbtofile/DdToFileSuite.scala
+++ b/src/test/scala/org/dbtofile/DdToFileSuite.scala
@@ -28,6 +28,9 @@ trait DdToFileSuite extends FunSuite with Matchers with BeforeAndAfterAll {
   val dbPass: String = "pass"
   val employeesDb: String = "employees"
 
+  override def convertToLegacyEqualizer[T](left: T): LegacyEqualizer[T] = new LegacyEqualizer(left)
+  override def convertToLegacyCheckingEqualizer[T](left: T): LegacyCheckingEqualizer[T] = new LegacyCheckingEqualizer(left)
+
   def  db = new EmbeddedH2
 
   def withEmbeddedDb(user: String, password: String, initScript: String, dbName: String)(test: => Unit) = {

--- a/src/test/scala/org/dbtofile/DdToFileSuite.scala
+++ b/src/test/scala/org/dbtofile/DdToFileSuite.scala
@@ -12,7 +12,7 @@ trait DdToFileSuite extends FunSuite with Matchers with BeforeAndAfterAll {
 
   def  db = new EmbeddedH2
 
-  def withEmbeddedDb(port: Int, user: String, password: String, initScript: String, dbName: String)(test: => Unit) = {
+  def withEmbeddedDb(user: String, password: String, initScript: String, dbName: String)(test: => Unit) = {
 //    val db = new EmbeddedMySql(port = port, dbUser = user, password = password)
 
     db.start
@@ -26,9 +26,8 @@ trait DdToFileSuite extends FunSuite with Matchers with BeforeAndAfterAll {
     }
   }
 
-  def withEmployeesDb(port: Int = dbPort, user: String = dbUser, password: String = dbPass) =
+  def withEmployeesDb(user: String = dbUser, password: String = dbPass) =
     withEmbeddedDb(
-      port = port,
       user = user,
       password = password,
       initScript = getClass.getResource("/employees_db.sql.zip").getFile,

--- a/src/test/scala/org/dbtofile/DdToFileSuite.scala
+++ b/src/test/scala/org/dbtofile/DdToFileSuite.scala
@@ -28,8 +28,8 @@ trait DdToFileSuite extends FunSuite with Matchers with BeforeAndAfterAll {
   val dbPass: String = "pass"
   val employeesDb: String = "employees"
 
-  override def convertToLegacyEqualizer[T](left: T): LegacyEqualizer[T] = new LegacyEqualizer(left)
-  override def convertToLegacyCheckingEqualizer[T](left: T): LegacyCheckingEqualizer[T] = new LegacyCheckingEqualizer(left)
+//  override def convertToLegacyEqualizer[T](left: T): LegacyEqualizer[T] = new LegacyEqualizer(left)
+//  override def convertToLegacyCheckingEqualizer[T](left: T): LegacyCheckingEqualizer[T] = new LegacyCheckingEqualizer(left)
 
   def  db = new EmbeddedH2
 

--- a/src/test/scala/org/dbtofile/ExecutionEnvironmentTest.scala
+++ b/src/test/scala/org/dbtofile/ExecutionEnvironmentTest.scala
@@ -40,7 +40,7 @@ class ExecutionEnvironmentTest extends DdToFileSuite {
         val tablesRs = metadata.getTables(catalog, schemaPattern, tableNamePattern, types)
 
         val tables = (for ((_, r) <- Iterator.continually((tablesRs.next(), tablesRs)).takeWhile(_._1)) yield {
-          (r.getString(2),r.getString(3))
+          (r.getString(2), r.getString(3))
         }).toList.filter(_._1 == "public").map(_._2)
 
         tables.foreach(table => {

--- a/src/test/scala/org/dbtofile/conf/ConfigurationTest.scala
+++ b/src/test/scala/org/dbtofile/conf/ConfigurationTest.scala
@@ -1,0 +1,93 @@
+package org.dbtofile.conf
+
+import java.io.File
+
+import org.dbtofile.DdToFileSuite
+import org.scalatest.Tag
+
+import scala.collection.mutable.ArrayBuffer
+
+class ConfigurationTest extends DdToFileSuite {
+
+  test("load configurations from YAML") {
+    val yaml = getClass getResource "/tables_conf.yaml"
+    val conf = Configuration.loadConfigurationFromYaml(new File(yaml.getFile))
+    conf.tables.length should be(7)
+    conf.merges.length should be(1)
+
+    val tables = conf.tables.groupBy(_.table)
+    val employees = tables("employees").headOption
+    val departments = tables("departments").headOption
+    require(employees.isDefined)
+    require(departments.isDefined)
+
+    employees.map(_.password) should be(departments.map(_.password))
+    employees.map(_.url) should be(departments.map(_.url))
+    employees.map(_.user) should be(departments.map(_.user))
+    employees.map(_.outputPath).get should be("target/employee.parquet")
+    departments.map(_.outputPath).get should be("target/departments.parquet")
+
+    val merge = conf.merges.head
+    merge.outputTable.outputPath should be("target/merged_employee.parquet")
+  }
+
+  ignore("load configuration from table metadata", Tag("slow")) {
+    val connectionString = db.connectionString(Some("employees"))
+    val user = "sa"
+    val password = ""
+    withEmployeesDb() {
+      val conn = db.jdbcConnection(Some("employees"))
+      try {
+        val metadata = conn.getMetaData
+        val catalog: String = conn.getCatalog
+        val schemaPattern: String = null
+        val tableNamePattern: String = null
+        val types: Array[String] = null
+
+        val tablesRs = metadata.getTables(catalog, schemaPattern, tableNamePattern, types)
+
+        val tables = (for ((_, r) <- Iterator.continually((tablesRs.next(), tablesRs)).takeWhile(_._1)) yield {
+          (r.getString(2), r.getString(3))
+        }).toList.filter(_._1 == "public").map(_._2)
+
+        val tableInfo: List[MergeInfo] = tables.flatMap(table => {
+          println(s"TABLE : $table")
+          val tInfo=TableInfo(
+            url=db.connectionString(Option(table)),
+            table = table,
+            password=password,
+            user = user,
+            outputPath = null,
+            outputFormat = null,
+            sql = null,
+            load = false)
+          val foreignKeys = metadata.getImportedKeys(catalog, null, table)
+          val mergeOps = ArrayBuffer[(MergeTableInfo,MergeTableInfo)]()
+          while (foreignKeys.next()) {
+            val base = MergeTableInfo(tInfo, foreignKeys.getString("PKCOLUMN_NAME"))
+            val childTInfo=TableInfo(
+              url=db.connectionString(Option( foreignKeys.getString("FKTABLE_NAME"))),
+              table =  foreignKeys.getString("FKTABLE_NAME"),
+              password=password,
+              user = user,
+              outputPath = null,
+              outputFormat = null,
+              sql = null,
+              load = false)
+
+            val child = MergeTableInfo(childTInfo, foreignKeys.getString("FKCOLUMN_NAME"))
+
+            mergeOps += ((base, child))
+          }
+          mergeOps.groupBy(_._1).map{case (baseTable, tablesToJoin)=> MergeInfo(baseTable, null, tablesToJoin.map(_._2).toArray)}
+        })
+
+
+      } finally {
+        if (conn != null) conn.close()
+      }
+
+    }
+  }
+
+}

--- a/src/test/scala/org/dbtofile/conf/DataSourceDefinitionTest.scala
+++ b/src/test/scala/org/dbtofile/conf/DataSourceDefinitionTest.scala
@@ -1,0 +1,49 @@
+/*
+ *     Licensed to the Apache Software Foundation (ASF) under one or more
+ *     contributor license agreements.  See the NOTICE file distributed with
+ *     this work for additional information regarding copyright ownership.
+ *     The ASF licenses this file to You under the Apache License, Version 2.0
+ *     (the "License"); you may not use this file except in compliance with
+ *     the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package org.dbtofile.conf
+
+import org.dbtofile.DdToFileSuite
+import org.scalatest.Tag
+
+class ListItemOps[T](item: T) {
+  def in(list: Seq[T]): Boolean = list.contains(item)
+}
+
+object ListItemOps {
+  implicit def stringToListItem(item: String):ListItemOps[String] = new ListItemOps(item)
+}
+
+class DataSourceDefinitionTest extends DdToFileSuite {
+  test("load data source definitions from table metadata", Tag("slow")) {
+    withEmployeesDb() {
+      val ds: Db = DataSourceDefinition.load(db.connectionString(Some("employees")), "sa", "")
+      require(ds.tables.length == 37) //H2 creates a lot of service tables
+      val childList = ds.childTables("employees").map(_.name)
+      require(childList.size == 4)
+      import org.dbtofile.conf.ListItemOps._
+      require("dept_emp" in childList, s"dept_emp is missing : ${childList.mkString(";")}")
+      require("titles" in childList,  s"departments is missing : ${childList.mkString(";")}")
+      require("dept_manager" in childList, s"dept_manager is missing : ${childList.mkString(";")}")
+      require("salaries" in childList, s"salaries is missing : ${childList.mkString(";")}")
+
+
+    }
+  }
+
+}

--- a/src/test/scala/org/dbtofile/conf/DataSourceDefinitionTest.scala
+++ b/src/test/scala/org/dbtofile/conf/DataSourceDefinitionTest.scala
@@ -33,7 +33,7 @@ class DataSourceDefinitionTest extends DdToFileSuite {
   test("load data source definitions from table metadata", Tag("slow")) {
     withEmployeesDb() {
       val ds: Db = DataSourceDefinition.load(db.connectionString(Some("employees")), "sa", "")
-      require(ds.tables.length == 37) //H2 creates a lot of service tables
+      require(ds.tables.length == 6) //H2 creates a lot of service tables
       val childList = ds.childTables("employees").map(_.name)
       require(childList.size == 4)
       import org.dbtofile.conf.ListItemOps._


### PR DESCRIPTION
I've implemented logic to fetch data source definition from table metadata (org.dbtofile.conf.Db). The structure is quite flexible and can be reflected to any convenient view.

I do believe we need to separate definitions of the data sources and data extraction  logic.
